### PR TITLE
Make API URL configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Personal Finance Tracker is a full-stack application combining a Node.js/Express
    ```
 4. **Prepare front-end (no extra dependencies)**
    The client is static HTML/CSS/JS.
+   If hosting the client separately from the server, set `window.API_BASE_URL`
+   before loading `script.js` to point at your API endpoint. It defaults to
+   `http://localhost:5000/api`.
 
 ## Configuration
 

--- a/client/script.js
+++ b/client/script.js
@@ -1,5 +1,8 @@
 let token = '';
-const API = 'http://localhost:5000/api';
+// Allow overriding the API base URL via a global variable, e.g.:
+// <script>window.API_BASE_URL = 'https://example.com/api';</script>
+// Defaults to the local development server.
+const API = window.API_BASE_URL || 'http://localhost:5000/api';
 let chart;
 
 async function login() {


### PR DESCRIPTION
## Summary
- allow overriding API base URL via `window.API_BASE_URL`
- document API URL configuration in README

## Testing
- `npm test`
- `npm run lint`

